### PR TITLE
Adding ntp pool servers as backups to tick and tock

### DIFF
--- a/files/ntp.conf
+++ b/files/ntp.conf
@@ -20,6 +20,10 @@ filegen clockstats file clockstats type day enable
 # pool: <http://www.pool.ntp.org/join.html>
 server tick.byu.edu
 server tock.byu.edu
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>


### PR DESCRIPTION
I think we should add the ntp pool as a backup for the campus servers. This makes ntp work no matter what, but prefers campus first. 

From http://www.pool.ntp.org/en/use.html: The 0, 1, 2 and 3.pool.ntp.org names point to a random set of servers that will change every hour.
